### PR TITLE
Changed year from 2016 to 2006 for validation

### DIFF
--- a/plugin/string.go
+++ b/plugin/string.go
@@ -82,7 +82,7 @@ func (p *Plugin) generateStringValidationCode(fieldName string, fieldValue strin
 		p.P(`}`)
 	}
 	if v.IsIso8601Date != nil && *v.IsIso8601Date {
-		p.P(`if !isValidDate("%s", %s) {`, "2016-01-02", fieldValue)
+		p.P(`if !isValidDate("%s", %s) {`, "2006-01-02", fieldValue)
 		p.generateErrorCode(fieldName, "", "{field} must be a date in the format YYYY-MM-DD", v, mv, field, "")
 		p.P(`}`)
 	}

--- a/validation.proto
+++ b/validation.proto
@@ -57,7 +57,7 @@ message FieldValidation {
 	optional bool is_uuid = 15;
   // validate using net/mail ParseAddress that this is a valid email
 	optional bool is_email = 16;
-  // validate using time.Parse that this is a valid date using the default format of YYYY-MM-DD (2016-01-02 in go's crazy syntax)
+  // validate using time.Parse that this is a valid date using the default format of YYYY-MM-DD (2006-01-02 in go's crazy syntax)
 	optional bool is_iso8601_date = 17;
   // use strings.Trim to trim whitespace from the value
 	optional bool trim = 18;


### PR DESCRIPTION
This _IS_ weird.  Best I could understand is that it needs to be 2006 because of go's epoch.  And we need to provide this string manually because there is no iso8601 format constant in go's time package. Anyway, 2016 was causing some invalid month errors so this fixes that.