### PR TITLE
go_package renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ func (s *server) MyRPC(ctx context.Context, req *pb.Request) (*pb.Response, erro
 * error: string - override predefined error messages.  You can use {field} and {value} as macros that get replaced with the
 field name and the required value.
 * transform_func: string - a function name that will be called like `m.Field = FuncName(m.Field)` allowing you to do any sort of custom transformation of the value that might not be supported in this package
+* do_not_validate: bool - if set to true, this field will not have validation logic generated; useful when using protobuf's "oneof" functionality
 
 ### String
 * not_empty_string: bool - make sure a string isn't ""

--- a/validation.proto
+++ b/validation.proto
@@ -3,7 +3,7 @@ syntax = "proto2";
 import "google/protobuf/descriptor.proto";
 
 package validation;
-option go_package = "validation";
+option go_package = "github.com/neophenix/protoc-gen-validation;validation";
 
 // The number here is supposed to be registered with google I think, I just did a random num gen
 extend google.protobuf.FieldOptions {


### PR DESCRIPTION
Upon upgrading to grpc-gateway/v2, it pulled in a new google.golang.org/protobuf version. It seems this is how they want to name go_package now:

2020/10/20 17:02:42 WARNING: Deprecated use of 'go_package' option without a full import path in "github.com/neophenix/protoc-gen-validation/validation.proto", please specify:
        option go_package = "github.com/neophenix/protoc-gen-validation;validation";
A future release of protoc-gen-go will require the import path be specified.
See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package for more information.