### PR TITLE
Parse out request parameters if they exist

### DIFF
--- a/cmd/protoc-gen-validation/main.go
+++ b/cmd/protoc-gen-validation/main.go
@@ -27,6 +27,10 @@ func main() {
 		g.Fail("no files to generate")
 	}
 
+	if p := g.Request.Parameter; p != nil {
+		g.CommandLineParameters(*p)
+	}
+
 	g.WrapTypes()
 	g.SetPackageNames()
 	g.BuildTypeNameMap()


### PR DESCRIPTION
This allows things like `--validation_opt=paths=source_relative` which is necessary when using the newer protobuf versions. Otherwise it would always save the generated validation code in a directory that matches the `.proto` file's `go_package` path.